### PR TITLE
Corrected the transparency setting for the exported PNG's.

### DIFF
--- a/Create-iMessage-icons.jsx
+++ b/Create-iMessage-icons.jsx
@@ -51,7 +51,7 @@ function main() {
 	var saveForWeb = new ExportOptionsSaveForWeb();
 	saveForWeb.format = SaveDocumentType.PNG;
 	saveForWeb.PNG8 = false;
-	saveForWeb.transparency = true;
+	saveForWeb.transparency = false;
 
 	//	delete metadata
 	doc.info = null;

--- a/Create-iMessage-stickers.jsx
+++ b/Create-iMessage-stickers.jsx
@@ -51,7 +51,7 @@ function main() {
 	var saveForWeb = new ExportOptionsSaveForWeb();
 	saveForWeb.format = SaveDocumentType.PNG;
 	saveForWeb.PNG8 = false;
-	saveForWeb.transparency = true;
+	saveForWeb.transparency = false;
 
 	//	delete metadata
 	doc.info = null;

--- a/Create-iOS-icons.jsx
+++ b/Create-iOS-icons.jsx
@@ -51,7 +51,7 @@ function main() {
 	var saveForWeb = new ExportOptionsSaveForWeb();
 	saveForWeb.format = SaveDocumentType.PNG;
 	saveForWeb.PNG8 = false;
-	saveForWeb.transparency = true;
+	saveForWeb.transparency = false;
 
 	//	delete metadata
 	doc.info = null;

--- a/Create-macOS-icons.jsx
+++ b/Create-macOS-icons.jsx
@@ -51,7 +51,7 @@ function main() {
 	var saveForWeb = new ExportOptionsSaveForWeb();
 	saveForWeb.format = SaveDocumentType.PNG;
 	saveForWeb.PNG8 = false;
-	saveForWeb.transparency = true;
+	saveForWeb.transparency = false;
 
 	//	delete metadata
 	doc.info = null;

--- a/Create-watchOS-icons.jsx
+++ b/Create-watchOS-icons.jsx
@@ -51,7 +51,7 @@ function main() {
 	var saveForWeb = new ExportOptionsSaveForWeb();
 	saveForWeb.format = SaveDocumentType.PNG;
 	saveForWeb.PNG8 = false;
-	saveForWeb.transparency = true;
+	saveForWeb.transparency = false;
 
 	//	delete metadata
 	doc.info = null;


### PR DESCRIPTION
App Store Connect insists that there be no alpha channel.  Making this change dealt with the issue.  The odd thing is that the readme states that the PNG's are exported as png-24, and yet the alpha channel was set to true.